### PR TITLE
clarifications

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -136,18 +136,20 @@ To connect a device to {{site.data.keyword.iot_short_notm}}:
       Where *org_id* is the ID of your {{site.data.keyword.iot_short_notm}} organization.
 
     * Port:
-      * 1883
+      * 1883 (disabled by default)
       * 8883 (encrypted)
       * 443 (websockets)
-    * Device ID: d:_org_id:device_type:device_id_
+    * Device ID: d:_org_id_:_device_type_:_device_id_
     * User name: use-token-auth
     * Password: _Authentication token_
-    * Event topic format: iot-2/evt/_event_id/fmt/format_string_
+    * Event topic format: iot-2/evt/_event_id_/fmt/_format_string_
 
       Where _event_id_ specifies the event name that's shown in {{site.data.keyword.iot_short_notm}}, and _format_string_ is the format of the event, such as JSON.
 
     * Message format: JSON
 
+  Example payload: { "d": {"_key1_": _"value1"_} }
+	
   For more information, see [MQTT connectivity for devices ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/support/knowledgecenter/SSQP8H/iot/platform/devices/mqtt.html){:new_window}.
 
 


### PR DESCRIPTION
Corrected italics (currently some underscores are visible and confusing), added a note about the port 1883 being disabled by default (a major headache to debug, as the error says "Authentication failed") and added a small but useful example of a payload (don't know what that is going to look like in the compiled version, but I think it would be useful to include)